### PR TITLE
优化了Comsumption.jsp页面的相关内容

### DIFF
--- a/WebRoot/WEB-INF/classes/com/wicloud/main/java/entity/Branddis.hbm.xml
+++ b/WebRoot/WEB-INF/classes/com/wicloud/main/java/entity/Branddis.hbm.xml
@@ -152,5 +152,11 @@
         <property name="other" type="java.lang.Double">
             <column name="other" precision="22" scale="0" />
         </property>
+        <property name="vivo" type="java.lang.Double">
+        	<column name="vivo" precision="22" scale="0" />
+        </property>
+        <property name="leTv" type="java.lang.Double">
+        	<column name="leTv" precision="22" scale="0" />
+        </property>
     </class>
 </hibernate-mapping>

--- a/WebRoot/WEB-INF/views/consumption.jsp
+++ b/WebRoot/WEB-INF/views/consumption.jsp
@@ -348,7 +348,7 @@
 		                    [jsonObj.brand[3].brand, e], 
 		                    [jsonObj.brand[4].brand, f], 
 		                    [jsonObj.brand[5].brand, g], 
-		                    [jsonObj.brand[6].brand, h], 
+		                    [jsonObj.brand[6].brand, h],
 		                    [jsonObj.brand[7].brand, i], 
 		                    [jsonObj.brand[8].brand, j], 
 		                    [jsonObj.brand[9].brand, k], 

--- a/WebRoot/WEB-INF/views/consumption.jsp
+++ b/WebRoot/WEB-INF/views/consumption.jsp
@@ -347,11 +347,7 @@
 		                    },
 		                    [jsonObj.brand[3].brand, e], 
 		                    [jsonObj.brand[4].brand, f], 
-		                    [jsonObj.brand[5].brand, g], 
-		                    [jsonObj.brand[6].brand, h],
-		                    [jsonObj.brand[7].brand, i], 
-		                    [jsonObj.brand[8].brand, j], 
-		                    [jsonObj.brand[9].brand, k], 
+		                    [jsonObj.brand[5].brand, g],  
 		                    [jsonObj.brand[10].brand, l]]
 		                }],
 		                tooltip: {

--- a/src/com/wicloud/main/java/dao/BranddisDAO.java
+++ b/src/com/wicloud/main/java/dao/BranddisDAO.java
@@ -79,6 +79,8 @@ public class BranddisDAO extends BaseHibernateDAO {
 	public static final String PHILIPS = "philips";
 	public static final String TCL = "tcl";
 	public static final String OTHER = "other";
+	public static final String VIVO = "vivo";
+	public static final String LETV = "leTv";
 
 	@Autowired
 	private HibernateTemplate hibernateTemplate;
@@ -317,6 +319,14 @@ public class BranddisDAO extends BaseHibernateDAO {
 	public List findByOther(Object other) {
 		return findByProperty(OTHER, other);
 	}
+	
+	public List findByVovo(Object vivo) {
+		return findByProperty(VIVO, vivo);
+	}
+	
+	public List findByLeTv(Object leTv) {
+		return findByProperty(LETV, leTv);
+	}
 
 	public List findAll() {
 		log.debug("finding all Branddis instances");
@@ -357,7 +367,8 @@ public class BranddisDAO extends BaseHibernateDAO {
 				.add(Projections.avg("Simcom")).add(Projections.avg("SHARP"))
 				.add(Projections.avg("Wisol")).add(Projections.avg("Wistron"))
 				.add(Projections.avg("Amoi")).add(Projections.avg("BIRD"))
-				.add(Projections.avg("Philips")).add(Projections.avg("TCL"));
+				.add(Projections.avg("Philips")).add(Projections.avg("TCL"))
+				.add(Projections.avg("vivo")).add(Projections.avg("leTv"));
 			criteria.setProjection(projection);
 			return hibernateTemplate.findByCriteria(criteria);
 		} catch (RuntimeException re) {
@@ -394,7 +405,8 @@ public class BranddisDAO extends BaseHibernateDAO {
 				.add(Projections.sum("Simcom")).add(Projections.sum("SHARP"))
 				.add(Projections.sum("Wisol")).add(Projections.sum("Wistron"))
 				.add(Projections.sum("Amoi")).add(Projections.sum("BIRD"))
-				.add(Projections.sum("Philips")).add(Projections.sum("TCL"));
+				.add(Projections.sum("Philips")).add(Projections.sum("TCL"))
+				.add(Projections.sum("vivo")).add(Projections.sum("leTv"));
 			criteria.setProjection(projection);
 			return hibernateTemplate.findByCriteria(criteria);
 		} catch (RuntimeException re) {

--- a/src/com/wicloud/main/java/entity/Branddis.hbm.xml
+++ b/src/com/wicloud/main/java/entity/Branddis.hbm.xml
@@ -152,5 +152,11 @@
         <property name="other" type="java.lang.Double">
             <column name="other" precision="22" scale="0" />
         </property>
+        <property name="vivo" type="java.lang.Double">
+        	<column name="vivo" precision="22" scale="0" />
+        </property>
+        <property name="leTv" type="java.lang.Double">
+        	<column name="leTv" precision="22" scale="0" />
+        </property>
     </class>
 </hibernate-mapping>

--- a/src/com/wicloud/main/java/entity/Branddis.java
+++ b/src/com/wicloud/main/java/entity/Branddis.java
@@ -57,6 +57,8 @@ public class Branddis extends com.wicloud.main.java.entity.BaseEntity implements
 	private Double Philips;
 	private Double TCL;
 	private Double other;
+	private Double vivo;
+	private Double leTv;
 
 	// Constructors
 
@@ -81,7 +83,7 @@ public class Branddis extends com.wicloud.main.java.entity.BaseEntity implements
 			Double chiMei, Double foxconn, Double garmin, Double gemtek,
 			Double mediaTek, Double qualcomm, Double hisense, Double roving,
 			Double simcom, Double sharp, Double wisol, Double wistron,
-			Double amoi, Double bird, Double philips, Double tcl, Double other) {
+			Double amoi, Double bird, Double philips, Double tcl, Double other, Double vivo, Double leTv) {
 		this.id = id;
 		this.counter = counter;
 		this.cKnown = cknown;
@@ -130,6 +132,8 @@ public class Branddis extends com.wicloud.main.java.entity.BaseEntity implements
 		this.Philips = philips;
 		this.TCL = tcl;
 		this.other = other;
+		this.vivo = vivo;
+		this.leTv = leTv;
 	}
 
 	// Property accessors
@@ -793,5 +797,23 @@ public class Branddis extends com.wicloud.main.java.entity.BaseEntity implements
 	public void setOther(Double other) {
 		this.other = other;
 	}
+
+	public Double getVivo() {
+		return vivo;
+	}
+
+	public void setVivo(Double vivo) {
+		this.vivo = vivo;
+	}
+
+	public Double getLeTv() {
+		return leTv;
+	}
+
+	public void setLeTv(Double leTv) {
+		this.leTv = leTv;
+	}
+	
+	
 
 }

--- a/src/com/wicloud/main/java/service/BranddisService.java
+++ b/src/com/wicloud/main/java/service/BranddisService.java
@@ -19,6 +19,17 @@ public class BranddisService {
 
 	@Autowired
 	private BranddisDAO branddisDao;
+	
+	public static final int PRICE_APPLE = 6499;
+	public static final int PRICE_HUAWEI = 2499;
+	public static final int PRICE_XIAOMI = 1799;
+	public static final int PRICE_OPPO = 2799;
+	public static final int PRICE_SAMSUNG = 3199;
+	public static final int PRICE_VIVO = 2798;
+	public static final int PRICE_MEIZU = 1099;
+	public static final int PRICE_LETV = 999;
+	public static final int PRICE_COOLPAD = 899;
+	public static final int PRICE_GIONEE = 3999;
 
 	public String avg(String start, String finish) {
 		// get newer and old from table totalinfo
@@ -73,6 +84,8 @@ public class BranddisService {
 			map.put("BIRD", (int) Wicloud.parseDoubleValue(objs[41]));
 			map.put("Philips", (int) Wicloud.parseDoubleValue(objs[42]));
 			map.put("TCL", (int) Wicloud.parseDoubleValue(objs[43]));
+			map.put("vivo", (int) Wicloud.parseDoubleValue(objs[44]));
+			map.put("leTv", (int) Wicloud.parseDoubleValue(objs[45]));
 			// 通过ArrayList构造函数把map.entrySet()转换成list
 			mappingList = new ArrayList<Map.Entry<String, Integer>>(map.entrySet());
 			// 通过比较器实现比较排序
@@ -135,6 +148,8 @@ public class BranddisService {
 				map1.put("BIRD", Wicloud.parseDoubleValue(objs[41]));
 				map1.put("Philips", Wicloud.parseDoubleValue(objs[42]));
 				map1.put("TCL", Wicloud.parseDoubleValue(objs[43]));
+				map1.put("vivo", Wicloud.parseDoubleValue(objs[44]));
+				map1.put("leTv", Wicloud.parseDoubleValue(objs[45]));
 				//通过ArrayList构造函数把map.entrySet()转换成list
 				mappingList1 = new ArrayList<Map.Entry<String, Double>>(map1.entrySet());
 				//通过比较器实现比较排序
@@ -153,30 +168,33 @@ public class BranddisService {
 			if(counter != 0) {
 				int price = 0;
 				Map<String, Integer> priceMap = new HashMap<String, Integer>(); 
-				priceMap.put("Samsung", 3265);
-				priceMap.put("Apple", 4780);
-				priceMap.put("Lenove", 852);
-				priceMap.put("Nokia", 2784);
-				priceMap.put("HUAWEI", 1459);
-				priceMap.put("Sony", 3256);
-				priceMap.put("HTC", 2364);
-				priceMap.put("Xiaomi", 1865);
-				priceMap.put("Meizu", 2296);
-				priceMap.put("Coolpad", 820);
+				priceMap.put("Apple", PRICE_APPLE);
+				priceMap.put("HUAWEI", PRICE_HUAWEI);
+				priceMap.put("Xiaomi", PRICE_XIAOMI);
+				priceMap.put("OPPO", PRICE_OPPO);
+				priceMap.put("Samsung", PRICE_SAMSUNG);
+				priceMap.put("vivo", PRICE_VIVO);
+				priceMap.put("Meizu", PRICE_MEIZU);
+				priceMap.put("leTv", PRICE_LETV);
+				priceMap.put("Coolpad", PRICE_COOLPAD);
+				priceMap.put("gionee", PRICE_GIONEE);
 				for(Map.Entry<String, Double> mapping : mappingList1) {
 					String brand1 = mapping.getKey();
 					if(priceMap.containsKey(brand1)) {
-						if(brand1.equals("HUAWEI")||brand1.equals("Xiaomi")){
-							c12=c12+mapping.getValue();
-						}else if(brand1.equals("Nokia")||brand1.equals("HTC")||brand1.equals("Meizu")){
-							c23=c23+mapping.getValue();
-						}else if(brand1.equals("Samsung")||brand1.equals("Apple")||brand1.equals("Sony")){
-							c35=c35+mapping.getValue();
+						if (brand1.equals("Apple")) {
+							c5 += mapping.getValue();
+						} else if (brand1.equals("Samsung") || brand1.equals("gionee")) {
+							c35 += mapping.getValue();
+						} else if (brand1.equals("HUAWEI") || brand1.equals("OPPO") || brand1.equals("vivo")) {
+							c23 += mapping.getValue();
+						} else if (brand1.equals("Xiaomi") || brand1.equals("Meizu")) {
+							c12 += mapping.getValue();
+						} else if (brand1.equals("Coolpad") || brand1.equals("leTv")) {
+							c1 = c1 + mapping.getValue();
 						}
 					}
 					
 				}
-				c1=counter-(c12+c23+c35+c5);
 				c12=(double)(Math.round(c12/counter*100)/100.0);
 				c23=(double)(Math.round(c23/counter*100)/100.0);
 				c35=(double)(Math.round(c35/counter*100)/100.0);


### PR DESCRIPTION
1、左边饼图，只显示top6，top10品牌数量显示的臃肿；
2、右边横向条形图更新了当前手机的最新价格，价格会在工作日报中说明；
3、根据2016年度手机分析报告，在数据库表branddis中添加了乐视和vivo手机类型，具体代码见与Branddis相关的几个类；